### PR TITLE
Update dragonBonesFormat.ts

### DIFF
--- a/src/format/dragonBonesFormat.ts
+++ b/src/format/dragonBonesFormat.ts
@@ -1505,7 +1505,7 @@ export class IKConstraintTimeline extends TypeTimeline {
  * @deprecated
  */
 export class SlotDeformTimeline extends TypeTimeline {
-    skin: string = ""; // Deprecated.
+    skin: string = "default"; // Deprecated.
     slot: string = ""; // Deprecated.
 }
 


### PR DESCRIPTION
Spine and Spine Viewer are fail to load converted json because of the missing value. 
It can be fixed by adding a 'default' value.